### PR TITLE
Improve paragraph breaking algorithm

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,8 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/data.xml "0.0.8"] ;; XML parsing
                  [org.apache.pdfbox/pdfbox "1.8.7"] ;; PDF
-                 [potemkin "0.3.9"] ;; Code organisation
-                 [prismatic/schema "0.3.0"] ;; Template validations
+                 [potemkin "0.3.10"] ;; Code organisation
+                 [prismatic/schema "0.3.1"] ;; Template validations
                  ]
   :deploy-repositories [["releases" :clojars]])
 

--- a/src/pdf_stamper/text/parsed.clj
+++ b/src/pdf_stamper/text/parsed.clj
@@ -366,7 +366,9 @@
                    (if (seq paragraph)
                      (conj paragraphs [actual-formatting paragraph])
                      paragraphs)
-                   (conj overflow [(assoc actual-formatting :broken true) o])] ;; 4
+                   ;; TODO: There is a bug here, when a paragraph is exactly as long as the space given,
+                   ;; the following paragraph will be marked as `:broken`. See issue #31
+                   (conj overflow [(assoc actual-formatting :broken (if (= (count overflow) 0) true false)) o])] ;; 4
                   [(- size-left 
                       (* paragraph-line-height (count paragraph))
                       (get-in actual-formatting [:spacing :paragraph :above])

--- a/test/pdf_stamper/manual/overflow_bullets2.clj
+++ b/test/pdf_stamper/manual/overflow_bullets2.clj
@@ -1,0 +1,29 @@
+;; This is a test designed to show overflowing of multi-line text holes, i.e. holes of type `:text-parsed`.
+;; Specifically, this test is about breaking bullet points over multiple pages.
+;;
+;; An image with solid colour is placed as the background of the text holes, such that we can visually spot whether the
+;; text fits within the box.
+(ns pdf-stamper.manual.overflow-bullets2
+  (:require
+    [pdf-stamper :refer :all]
+    [clojure.edn :as edn]))
+
+(def template-1 (edn/read-string (slurp "test/templates/overflow_bullets/template-1.edn")))
+(def template-pdf-1 "test/templates/overflow_bullets/template-1.pdf")
+
+(def background (javax.imageio.ImageIO/read (clojure.java.io/as-file "test/templates/overflow_bullets/background.png")))
+(def text
+  "<pp><p>Introductory paragraph of text spanning multiple lines.</p><ul><li>This is a bullet that is much longer than any bullets you </li><li>would normally see and </li><li>addtionally it is without </li><li>stops or breaks making it even harder to read than it should be </li><li>although bullets should never be very long in any case. </li><li>It is even longer than you had imagined, and now it suddenly contains a comma!</li></ul><p>This is just to test that paragraph afterwards look correct.</p></pp>")
+
+(def context (->> base-context
+                  (add-template template-1 template-pdf-1)))
+
+(def pages
+  [{:template :template-1
+    :locations {:background {:contents {:image background}}
+                :text {:contents {:text text}}}}])
+
+(def out (fill-pages pages context))
+(.writeTo out (java.io.FileOutputStream. "out/overflow_bullets2.pdf"))
+(.close out)
+

--- a/test/pdf_stamper/manual/overflow_bullets3.clj
+++ b/test/pdf_stamper/manual/overflow_bullets3.clj
@@ -1,0 +1,29 @@
+;; This is a test designed to show overflowing of multi-line text holes, i.e. holes of type `:text-parsed`.
+;; Specifically, this test is about breaking bullet points over multiple pages.
+;;
+;; An image with solid colour is placed as the background of the text holes, such that we can visually spot whether the
+;; text fits within the box.
+(ns pdf-stamper.manual.overflow-bullets3
+  (:require
+    [pdf-stamper :refer :all]
+    [clojure.edn :as edn]))
+
+(def template-1 (edn/read-string (slurp "test/templates/overflow_bullets/template-1.edn")))
+(def template-pdf-1 "test/templates/overflow_bullets/template-1.pdf")
+
+(def background (javax.imageio.ImageIO/read (clojure.java.io/as-file "test/templates/overflow_bullets/background.png")))
+(def text
+  "<pp><p>Introductory paragraph of text spanning multiple lines.</p><ul><li>This is a bullet that is much longer than any bullets you </li><li>would normally see and </li><li>addtionally it is without any form or another of any reasonable kind of fishy or non-fishy, evil or good, funny or sad, fluffy or concrete, light or dark, naughty or nice, warm or on ice, true or false </li><li>stops or breaks making it even harder to read than it should be </li><li>although bullets should never be very long in any case. </li><li>It is even longer than you had imagined, and now it suddenly contains a comma!</li></ul><p>This is just to test that paragraph afterwards look correct.</p></pp>")
+
+(def context (->> base-context
+                  (add-template template-1 template-pdf-1)))
+
+(def pages
+  [{:template :template-1
+    :locations {:background {:contents {:image background}}
+                :text {:contents {:text text}}}}])
+
+(def out (fill-pages pages context))
+(.writeTo out (java.io.FileOutputStream. "out/overflow_bullets3.pdf"))
+(.close out)
+


### PR DESCRIPTION
Previously every single overflowing paragraph would be marked as `:broken`, even though it should only ever be the first of the overflowing paragraphs. This PR mostly solves this issue, though there is still a problem with this solution (see issue #31).

The proper solution for this problem is probably doing a proper tokenization of text to be stamped; but that is for another issue (e.g. #28). 

Closes #30 