### PR TITLE
Fix error where Math/abs would fail with fractions

### DIFF
--- a/src/pdf_stamper/images.clj
+++ b/src/pdf_stamper/images.clj
@@ -45,8 +45,8 @@
                                                         :b-height height
                                                         :i-width img-width
                                                         :i-height img-height})
-        new-x (+ x (Math/abs (/ (- width scaled-width) 2)))
-        new-y (+ y (Math/abs (/ (- height scaled-height) 2)))]
+        new-x (+ x (Math/abs (double (/ (- width scaled-width) 2))))
+        new-y (+ y (Math/abs (double (/ (- height scaled-height) 2))))]
     (.. c-stream (drawXObject image new-x new-y scaled-width scaled-height))))
 
 (defn- draw-image


### PR DESCRIPTION
The problem is that Java's `Math/abs` doesn't know how to handle Clojure's fractions (returned, for example, by `(/ 3 2)`), therefore this PR converts division result to `double`, before passing it to `abs`.
