### PR TITLE
Skip page

### DIFF
--- a/src/pdf_stamper.clj
+++ b/src/pdf_stamper.clj
@@ -127,7 +127,24 @@
 ;;
 ;; pdf-stamper exists to fill data onto pages while following a pre-defined layout. This is where the magic happens.
 
-(defn- skip-page-with
+(defn- skip-page?
+  "The page should be skipped if the template specifies that it can only be printed
+  on a specific page, but supplies no filler template."
+  [template number-of-pages]
+  (let [{:keys [pages filler]} (:only-on template)]
+    (cond
+      (and (even? number-of-pages)
+           (= pages :even))
+      (not filler)
+      
+      (and (odd? number-of-pages)
+           (= pages :odd))
+      (not filler)
+      
+      :default
+      false)))
+
+(defn- insert-before
   "Returns a template to use for a filler page if appropriate, nil otherwise."
   [template number-of-pages]
   (let [{:keys [pages filler]} (:only-on template)]
@@ -189,29 +206,33 @@
   (assert (page-template-exists? page-data context)
           (str "No template " (:template page-data) " for page."))
   (let [template (context/template (:template page-data) context)]
-    (when-let [filler (skip-page-with template (.getNumberOfPages document))]
-      (let [filler-data {:template filler
-                         :locations (:filler-locations page-data)}]
-        (fill-page document filler-data context)))
-    (let [template-overflow (:overflow template)
-          template-transforms (:transform-pages template)
-          template-holes (:holes template)
-          template-doc (context/template-document (:template page-data) context)
-          template-page (-> template-doc (.getDocumentCatalog) (.getAllPages) (.get 0))
-          template-c-stream (PDPageContentStream. document template-page true false)]
-     (.addPage document template-page)
-     (let [overflows (fill-holes document template-c-stream (sort-by :priority template-holes) page-data context)
-           overflow-page-data {:template template-overflow
-                               :locations (when (seq overflows)
-                                            (merge (:locations page-data) overflows))}]
-       (when-let [transforms (transform-page-with template (.getNumberOfPages document))]
-         (doseq [t transforms]
-           (transform template-page t)))
-       (.close template-c-stream)
-       (if (and (seq (:locations overflow-page-data))
-                (:template overflow-page-data))
-         (conj (fill-page document overflow-page-data context) template-doc)
-         [template-doc])))))
+    (if (skip-page? template (.getNumberOfPages document))
+      []
+      (do
+        (when-let [filler (insert-before template (.getNumberOfPages document))]
+          (assert filler)
+          (let [filler-data {:template filler
+                             :locations (:filler-locations page-data)}]
+            (fill-page document filler-data context)))
+        (let [template-overflow (:overflow template)
+              template-transforms (:transform-pages template)
+              template-holes (:holes template)
+              template-doc (context/template-document (:template page-data) context)
+              template-page (-> template-doc (.getDocumentCatalog) (.getAllPages) (.get 0))
+              template-c-stream (PDPageContentStream. document template-page true false)]
+          (.addPage document template-page)
+          (let [overflows (fill-holes document template-c-stream (sort-by :priority template-holes) page-data context)
+                overflow-page-data {:template template-overflow
+                                    :locations (when (seq overflows)
+                                                 (merge (:locations page-data) overflows))}]
+            (when-let [transforms (transform-page-with template (.getNumberOfPages document))]
+              (doseq [t transforms]
+                (transform template-page t)))
+            (.close template-c-stream)
+            (if (and (seq (:locations overflow-page-data))
+                     (:template overflow-page-data))
+              (conj (fill-page document overflow-page-data context) template-doc)
+              [template-doc])))))))
 
 (defn fill-pages
   "When the context is populated with fonts and templates, this is the

--- a/src/pdf_stamper/schemas.clj
+++ b/src/pdf_stamper/schemas.clj
@@ -84,7 +84,7 @@
   {:name s/Keyword
    (s/optional-key :overflow) s/Keyword
    (s/optional-key :only-on) {:pages (s/enum :even :odd)
-                              :filler s/Keyword} ;; TODO: Somehow check that the filler doesn't specify that it can only be printed on the same pages as this template
+                              (s/optional-key :filler) s/Keyword} ;; TODO: Somehow check that the filler doesn't specify that it can only be printed on the same pages as this template
    (s/optional-key :transform-pages) (s/constrained {(s/optional-key :even) Transforms
                                                      (s/optional-key :odd) Transforms}
                                                     not-empty)

--- a/test/templates/transform_only_on/template-1.edn
+++ b/test/templates/transform_only_on/template-1.edn
@@ -1,6 +1,5 @@
 {:name :template-1
- :only-on {:pages :odd
-           :filler :template-1-filler}
+ :only-on {:pages :even}
  :holes [{:name :centered-image
           :height 50.0
           :width 80.0

--- a/tests-manual/pdf_stamper/manual/transform_only_on.clj
+++ b/tests-manual/pdf_stamper/manual/transform_only_on.clj
@@ -16,7 +16,14 @@
                   (add-template template-1-filler template-pdf-1)))
 
 (def pages
-  [{:template :template-1
+  [{:template :template-1-filler
+    :locations {:centered-image {:contents {:image background}}
+                :centered-text {:contents {:text text}}
+                :top-image {:contents {:image background}}
+                :top-text {:contents {:text text}}
+                :bottom-image {:contents {:image background}}
+                :bottom-text {:contents {:text text}}}}
+   {:template :template-1
     :locations {:centered-image {:contents {:image background}}
                 :centered-text {:contents {:text text}}
                 :top-image {:contents {:image background}}
@@ -32,6 +39,13 @@
                 :bottom-image {:contents {:image background}}
                 :bottom-text {:contents {:text text}}}
     :filler-locations {:centered-text {:contents {:text filler-text}}}}
+   {:template :template-1-filler
+    :locations {:centered-image {:contents {:image background}}
+                :centered-text {:contents {:text text}}
+                :top-image {:contents {:image background}}
+                :top-text {:contents {:text text}}
+                :bottom-image {:contents {:image background}}
+                :bottom-text {:contents {:text text}}}}
    {:template :template-1
     :locations {:centered-image {:contents {:image background}}
                 :centered-text {:contents {:text text}}


### PR DESCRIPTION
## Changelog

- Allow `:only-on` template key to skip a page entirely.

## Description

This is an addon to #43. Now, if a template specifies the `:only-on` key but does not supply the `:filler` key, pages with this template will be skipped entirely if they would not be printed on the pages specified by the `:pages` key.