### PR TITLE
Fix random COS exceptions due to closed documents

### DIFF
--- a/src/pdf_stamper.clj
+++ b/src/pdf_stamper.clj
@@ -224,11 +224,12 @@
   (let [template (context/template (:template page-data) context)]
     (if (skip-page? template (inc (.getNumberOfPages document)))
       []
-      (let [fill-page-vec (when-let [fillers (seq (insert-before template (inc (.getNumberOfPages document))))]
-                            (doseq [filler fillers]
-                              (let [filler-data {:template filler
-                                                 :locations (:filler-locations page-data)}]
-                                (fill-page document filler-data context))))
+      (let [fill-page-vec (reduce (fn [acc filler]
+                                    (let [filler-data {:template filler
+                                                       :locations (:filler-locations page-data)}]
+                                      (into acc (fill-page document filler-data context))))
+                                  []
+                                  (insert-before template (inc (.getNumberOfPages document))))
             template-overflow (:overflow template)
             template-transforms (:transform-pages template)
             template-holes (if (odd? (inc (.getNumberOfPages document)))


### PR DESCRIPTION
There were a couple of bugs here:

**Ensure a value for fill-page-vec**
This was definitely a bug, where fill-page-vec would always be nil. Rewriting as
a reduce is the simplest way of ensuring a return value while still forcing
side-effects.

**Use `PDDocument/importPage` instead of `PDDocument/addPage`**
This will copy the page into the document, instead of just referencing a page in
another document. This will fix potential exceptions due to the referenced
document being closed before the new document.

**Use non-deprecated image drawing facility from PDFBox**
This is not necessarily a part of this bug, but it cannot hurt to remove calls to
deprecated methods.